### PR TITLE
Added support for SH1106 display

### DIFF
--- a/SH1106_example.yaml
+++ b/SH1106_example.yaml
@@ -1,0 +1,10 @@
+substitutions:
+  node_name: heart-rate-display
+  node_platform: ESP32
+  node_board: esp-wrover-kit
+  ble_mac: AA:BB:CC:DD:EE:FF
+
+packages:
+  base: !include common/base.yaml
+  heart_rate: !include common/heart_rate.yaml
+  display: !include common/display_tdisplay.yaml

--- a/common/SH1106_display.yaml
+++ b/common/SH1106_display.yaml
@@ -1,0 +1,17 @@
+# Configuration for an 1,3'' OLED SH1106 display
+
+i2c:
+  - id: bus_a
+    sda: 21
+    scl: 22
+    scan: false
+
+display:
+  - platform: ssd1306_i2c
+    model: "SH1106 128x64"
+    #reset_pin: 0
+    address: 0x3C
+    lambda: |-
+      it.rectangle(0,  0, it.get_width(), it.get_height());
+      it.printf(it.get_width() / 2, 10, id(font_roboto_10), TextAlign::CENTER, "%s", id(heart_rate_sensor_name).state.c_str());
+      it.printf(it.get_width() /2, 35, id(font_roboto_20), TextAlign::CENTER, "%.1f bpm", id(heart_rate_measurement).state);

--- a/common/base.yaml
+++ b/common/base.yaml
@@ -38,3 +38,9 @@ font:
   - file: "fonts/Roboto-Medium.ttf"
     id: font_roboto_big
     size: 44
+  - file: "fonts/Roboto-Medium.ttf"
+    id: font_roboto_10
+    size: 10
+  - file: "fonts/Roboto-Medium.ttf"
+    id: font_roboto_20
+    size: 20


### PR DESCRIPTION
I added support for an OLED 1,3'' SH1106 display. I used an ESP32 Wroom 32D and was also able to add the OTA feature, but I did not add that here.